### PR TITLE
Update hip_runtime_api.h

### DIFF
--- a/include/hip/hcc_detail/hip_runtime_api.h
+++ b/include/hip/hcc_detail/hip_runtime_api.h
@@ -2528,7 +2528,7 @@ hipError_t hipModuleLoad(hipModule_t* module, const char* fname);
 
 hipError_t hipModuleUnload(hipModule_t module);
 
-/**
+/**/
  * @brief Function with kname will be extracted if present in module
  *
  * @param [in] module
@@ -2549,7 +2549,7 @@ hipError_t hipModuleGetFunction(hipFunction_t* function, hipModule_t module, con
  * @returns hipSuccess, hipErrorInvalidDeviceFunction
  */
 
-hipError_t hipFuncGetAttributes(hipFuncAttributes* attr, const void* func);
+hipError_t hipFuncGetAttributes(struct hipFuncAttributes* attr, const void* func);
 
 struct Agent_global {
 


### PR DESCRIPTION
when i try to use mpicc or gcc to compile a c language code which call some hip runtime api , error occured as
> /path/to/hcc_detail/hip_runtime_api.h:2268:33: error: unknown type name ‘hipFuncAttributes’; 
> hipFuncGetAttributes(hipFuncAttributes* attr, const void* func);
 
add ' struct ' for the first parameter of hipFuncGetAttributes will get ride of this problem.